### PR TITLE
Fix generated output

### DIFF
--- a/cmd/app-config/generator/generator.go
+++ b/cmd/app-config/generator/generator.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"log"
 	"path/filepath"
-	"strings"
 
 	"github.com/goliatone/go-generators/internal/appconfig"
 	"github.com/goliatone/go-generators/internal/common/generator"
@@ -14,18 +13,12 @@ func Run() {
 	var opts generator.Options
 
 	flag.StringVar(&opts.InputFile, "input", "config.go", "Input file containing the config structs")
-	flag.StringVar(&opts.OutputFile, "output", "", "Output file for generated code (default: {input}_getters.go)")
+	flag.StringVar(&opts.OutputFile, "output", "", "Output file for generated code")
 	flag.StringVar(&opts.PackageName, "pkg", "config", "Package name for generated code (default: config)")
 	flag.Parse()
 
 	if opts.InputFile == "" {
 		log.Fatal("Input file must be specified")
-	}
-
-	if opts.OutputFile == "" {
-		ext := filepath.Ext(opts.InputFile)
-		basename := strings.TrimSuffix(opts.InputFile, ext)
-		opts.OutputFile = basename + "_getters" + ext
 	}
 
 	// Convert to absolute paths

--- a/internal/appconfig/testdata/basic/golden/app_config.go
+++ b/internal/appconfig/testdata/basic/golden/app_config.go
@@ -7,8 +7,9 @@ type Config struct {
 }
 
 type Database struct {
-	Dsn    string `koanf:"dsn"`
-	Debug  bool   `koanf:"debug"`
-	Driver string `koanf:"driver"`
-	Server string `koanf:"server"`
+	Dsn        string `koanf:"dsn"`
+	Debug      bool   `koanf:"debug"`
+	Driver     string `koanf:"driver"`
+	Server     string `koanf:"server"`
+	DefaultTTL string `koanf:"default_ttl"`
 }

--- a/internal/appconfig/testdata/basic/golden/app_config.go
+++ b/internal/appconfig/testdata/basic/golden/app_config.go
@@ -7,9 +7,9 @@ type Config struct {
 }
 
 type Database struct {
-	Dsn        string `koanf:"dsn"`
 	Debug      bool   `koanf:"debug"`
-	Driver     string `koanf:"driver"`
-	Server     string `koanf:"server"`
 	DefaultTTL string `koanf:"default_ttl"`
+	Driver     string `koanf:"driver"`
+	Dsn        string `koanf:"dsn"`
+	Server     string `koanf:"server"`
 }

--- a/internal/appconfig/testdata/basic/input/config.json
+++ b/internal/appconfig/testdata/basic/input/config.json
@@ -3,6 +3,7 @@
         "dsn": "file:test.db?cache=shared",
         "debug": true,
         "driver": "sqlite",
-        "server": "file"
+        "server": "file",
+        "default_ttl": "24h"
     }
 }

--- a/internal/appconfig/testdata/complex/golden/app_config.go
+++ b/internal/appconfig/testdata/complex/golden/app_config.go
@@ -4,29 +4,29 @@ package appconfig_complex
 
 type Config struct {
 	Auth     Auth     `koanf:"auth"`
-	Views    Views    `koanf:"views"`
 	Database Database `koanf:"database"`
+	Views    Views    `koanf:"views"`
 }
 
 type Auth struct {
-	Users      []User `koanf:"users"`
 	Enabled    bool   `koanf:"enabled"`
 	SessionTTL string `koanf:"session_ttl"`
+	Users      []User `koanf:"users"`
+}
+
+type Database struct {
+	Debug  bool   `koanf:"debug"`
+	Driver string `koanf:"driver"`
+	Dsn    string `koanf:"dsn"`
+	Server string `koanf:"server"`
 }
 
 type User struct {
-	Username string `koanf:"username"`
 	Password string `koanf:"password"`
+	Username string `koanf:"username"`
 }
 
 type Views struct {
 	Dir           string `koanf:"dir"`
 	FileExtension string `koanf:"file_extension"`
-}
-
-type Database struct {
-	Dsn    string `koanf:"dsn"`
-	Debug  bool   `koanf:"debug"`
-	Driver string `koanf:"driver"`
-	Server string `koanf:"server"`
 }

--- a/internal/appconfig/testdata/complex/golden/app_config.go
+++ b/internal/appconfig/testdata/complex/golden/app_config.go
@@ -3,9 +3,15 @@
 package appconfig_complex
 
 type Config struct {
-	Database Database `koanf:"database"`
 	Auth     Auth     `koanf:"auth"`
 	Views    Views    `koanf:"views"`
+	Database Database `koanf:"database"`
+}
+
+type Auth struct {
+	Users      []User `koanf:"users"`
+	Enabled    bool   `koanf:"enabled"`
+	SessionTTL string `koanf:"session_ttl"`
 }
 
 type User struct {
@@ -23,10 +29,4 @@ type Database struct {
 	Debug  bool   `koanf:"debug"`
 	Driver string `koanf:"driver"`
 	Server string `koanf:"server"`
-}
-
-type Auth struct {
-	Enabled    bool   `koanf:"enabled"`
-	SessionTTL string `koanf:"session_ttl"`
-	Users      []User `koanf:"users"`
 }


### PR DESCRIPTION
This PR fixes how we generate the go code, now it sorts structs and structs' fields alphabetically so every time we run go generate we get the same file if nothing changes.